### PR TITLE
Patch on BlockFrequencyInfoImpl.cpp to round up profile count

### DIFF
--- a/lib/Analysis/BlockFrequencyInfoImpl.cpp
+++ b/lib/Analysis/BlockFrequencyInfoImpl.cpp
@@ -138,8 +138,9 @@ static void combineWeight(Weight &W, const Weight &OtherW) {
 static void combineWeightsBySorting(WeightList &Weights) {
   // Sort so edges to the same node are adjacent.
   std::sort(Weights.begin(), Weights.end(),
-            [](const Weight &L,
-               const Weight &R) { return L.TargetNode < R.TargetNode; });
+            [](const Weight &L, const Weight &R) {
+              return L.TargetNode < R.TargetNode;
+            });
 
   // Combine adjacent edges.
   WeightList::iterator O = Weights.begin();
@@ -224,8 +225,8 @@ void Distribution::normalize() {
     // sum of the weights, but let's double-check.
     assert(Total == std::accumulate(Weights.begin(), Weights.end(), UINT64_C(0),
                                     [](uint64_t Sum, const Weight &W) {
-                      return Sum + W.Amount;
-                    }) &&
+                                      return Sum + W.Amount;
+                                    }) &&
            "Expected total to be correct");
     return;
   }
@@ -549,6 +550,8 @@ BlockFrequencyInfoImplBase::getProfileCountFromFreq(const Function &F,
   APInt BlockFreq(128, Freq);
   APInt EntryFreq(128, getEntryFreq());
   BlockCount *= BlockFreq;
+  BlockCount +=
+      EntryFreq.ashr(1); // Use right-shift to implement divided by two
   BlockCount = BlockCount.udiv(EntryFreq);
   return BlockCount.getLimitedValue();
 }
@@ -644,8 +647,7 @@ template <> struct GraphTraits<IrreducibleGraph> {
 /// Find entry blocks and other blocks with backedges, which exist when \c G
 /// contains irreducible sub-SCCs.
 static void findIrreducibleHeaders(
-    const BlockFrequencyInfoImplBase &BFI,
-    const IrreducibleGraph &G,
+    const BlockFrequencyInfoImplBase &BFI, const IrreducibleGraph &G,
     const std::vector<const IrreducibleGraph::IrrNode *> &SCC,
     LoopData::NodeList &Headers, LoopData::NodeList &Others) {
   // Map from nodes in the SCC to whether it's an entry block.
@@ -752,8 +754,8 @@ BlockFrequencyInfoImplBase::analyzeIrreducible(
   return make_range(Loops.begin(), Insert);
 }
 
-void
-BlockFrequencyInfoImplBase::updateLoopWithIrreducible(LoopData &OuterLoop) {
+void BlockFrequencyInfoImplBase::updateLoopWithIrreducible(
+    LoopData &OuterLoop) {
   OuterLoop.Exits.clear();
   for (auto &Mass : OuterLoop.BackedgeMass)
     Mass = BlockMass::getEmpty();

--- a/lib/Analysis/BlockFrequencyInfoImpl.cpp
+++ b/lib/Analysis/BlockFrequencyInfoImpl.cpp
@@ -547,8 +547,10 @@ BlockFrequencyInfoImplBase::getProfileCountFromFreq(const Function &F,
   // Use 128 bit APInt to do the arithmetic to avoid overflow.
   APInt BlockCount(128, EntryCount.getValue());
   APInt BlockFreq(128, Freq);
-  APInt EntryFreq(128, getEntryFreq());
+  auto EntryFreqTemp = getEntryFreq();
+  APInt EntryFreq(128, EntryFreqTemp);
   BlockCount *= BlockFreq;
+  BlockCount += EntryFreqTemp / 2;
   BlockCount = BlockCount.udiv(EntryFreq);
   return BlockCount.getLimitedValue();
 }

--- a/lib/Analysis/BlockFrequencyInfoImpl.cpp
+++ b/lib/Analysis/BlockFrequencyInfoImpl.cpp
@@ -138,9 +138,8 @@ static void combineWeight(Weight &W, const Weight &OtherW) {
 static void combineWeightsBySorting(WeightList &Weights) {
   // Sort so edges to the same node are adjacent.
   std::sort(Weights.begin(), Weights.end(),
-            [](const Weight &L, const Weight &R) {
-              return L.TargetNode < R.TargetNode;
-            });
+            [](const Weight &L,
+               const Weight &R) { return L.TargetNode < R.TargetNode; });
 
   // Combine adjacent edges.
   WeightList::iterator O = Weights.begin();
@@ -225,8 +224,8 @@ void Distribution::normalize() {
     // sum of the weights, but let's double-check.
     assert(Total == std::accumulate(Weights.begin(), Weights.end(), UINT64_C(0),
                                     [](uint64_t Sum, const Weight &W) {
-                                      return Sum + W.Amount;
-                                    }) &&
+                      return Sum + W.Amount;
+                    }) &&
            "Expected total to be correct");
     return;
   }
@@ -550,8 +549,6 @@ BlockFrequencyInfoImplBase::getProfileCountFromFreq(const Function &F,
   APInt BlockFreq(128, Freq);
   APInt EntryFreq(128, getEntryFreq());
   BlockCount *= BlockFreq;
-  BlockCount +=
-      EntryFreq.ashr(1); // Use right-shift to implement divided by two
   BlockCount = BlockCount.udiv(EntryFreq);
   return BlockCount.getLimitedValue();
 }
@@ -647,7 +644,8 @@ template <> struct GraphTraits<IrreducibleGraph> {
 /// Find entry blocks and other blocks with backedges, which exist when \c G
 /// contains irreducible sub-SCCs.
 static void findIrreducibleHeaders(
-    const BlockFrequencyInfoImplBase &BFI, const IrreducibleGraph &G,
+    const BlockFrequencyInfoImplBase &BFI,
+    const IrreducibleGraph &G,
     const std::vector<const IrreducibleGraph::IrrNode *> &SCC,
     LoopData::NodeList &Headers, LoopData::NodeList &Others) {
   // Map from nodes in the SCC to whether it's an entry block.
@@ -754,8 +752,8 @@ BlockFrequencyInfoImplBase::analyzeIrreducible(
   return make_range(Loops.begin(), Insert);
 }
 
-void BlockFrequencyInfoImplBase::updateLoopWithIrreducible(
-    LoopData &OuterLoop) {
+void
+BlockFrequencyInfoImplBase::updateLoopWithIrreducible(LoopData &OuterLoop) {
   OuterLoop.Exits.clear();
   for (auto &Mass : OuterLoop.BackedgeMass)
     Mass = BlockMass::getEmpty();

--- a/lib/Analysis/BlockFrequencyInfoImpl.cpp
+++ b/lib/Analysis/BlockFrequencyInfoImpl.cpp
@@ -547,11 +547,11 @@ BlockFrequencyInfoImplBase::getProfileCountFromFreq(const Function &F,
   // Use 128 bit APInt to do the arithmetic to avoid overflow.
   APInt BlockCount(128, EntryCount.getValue());
   APInt BlockFreq(128, Freq);
-  auto EntryFreqTemp = getEntryFreq();
-  APInt EntryFreq(128, EntryFreqTemp);
+  auto EntryFreq = getEntryFreq();
+  APInt EntryFreqAPInt(128, EntryFreq);
   BlockCount *= BlockFreq;
-  BlockCount += EntryFreqTemp / 2;
-  BlockCount = BlockCount.udiv(EntryFreq);
+  BlockCount += EntryFreq / 2;
+  BlockCount = BlockCount.udiv(EntryFreqAPInt);
   return BlockCount.getLimitedValue();
 }
 

--- a/test/Transforms/StructFieldCacheAnalysis/filter.ll
+++ b/test/Transforms/StructFieldCacheAnalysis/filter.ll
@@ -13,7 +13,7 @@
 ; CHECK: Hotness >=33: 0
 ; CHECK: Hotness >=67: 2
 ; CHECK: There are 2 struct types are accessed in the program
-; CHECK: Struct [struct.FooBar4] defined as global struct has 1 accesses and 69 execution count.
+; CHECK: Struct [struct.FooBar4] defined as global struct has 1 accesses and 70 execution count.
 ; CHECK: Struct [struct.FooBar2] defined as global struct has 1 accesses and 100 execution count.
 ; CHECK: Case Struct filtered out due to colder than a ratio of maximum hotness was found 1 times
 


### PR DESCRIPTION
This patch is used to update BlockFrequencyInfo to round up profile execution count. There should only be a single change at line 553. All the other changes is because I ran clang-format and the tool reorganized the file.
Also, I haven't created a test case for this change because it might need some effort on creating a test case and print some message to check it. I suggest we can skip it since it's only a single line change.
Please take a look at this pull request and approve it soon. Thank!